### PR TITLE
feat: 공연 관련 entity 및 repository 구현

### DIFF
--- a/backend/src/main/java/com/pickgo/performance/area/entity/PerformanceArea.java
+++ b/backend/src/main/java/com/pickgo/performance/area/entity/PerformanceArea.java
@@ -1,0 +1,35 @@
+package com.pickgo.performance.area.entity;
+
+import com.pickgo.global.entity.BaseEntity;
+import com.pickgo.performance.performance.entity.Performance;
+import com.pickgo.performance.seat.entity.Seat;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class PerformanceArea extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "performanceArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Seat> seats = new ArrayList<>();
+}

--- a/backend/src/main/java/com/pickgo/performance/area/repository/PerformanceAreaRepository.java
+++ b/backend/src/main/java/com/pickgo/performance/area/repository/PerformanceAreaRepository.java
@@ -1,0 +1,7 @@
+package com.pickgo.performance.area.repository;
+
+import com.pickgo.performance.area.entity.PerformanceArea;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceAreaRepository extends JpaRepository<PerformanceArea, Long> {
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/entity/Performance.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/entity/Performance.java
@@ -1,0 +1,67 @@
+package com.pickgo.performance.performance.entity;
+
+import com.pickgo.global.entity.BaseEntity;
+import com.pickgo.performance.area.entity.PerformanceArea;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class Performance extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private Integer runtime;
+
+    @Column(nullable = false)
+    private String poster;
+
+    @Column(nullable = false)
+    private String state;
+
+    @Column(nullable = false)
+    private Integer minAge;
+
+    @Column(nullable = false)
+    private String casts;
+
+    @Column(nullable = false)
+    private String productionCompany;
+
+    @Column(nullable = false)
+    private String type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "venue_id", nullable = false)
+    private Venue venue;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PerformanceIntro> performanceIntros = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PerformanceArea> performanceAreas = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PerformanceSession> performanceSessions = new ArrayList<>();
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/entity/PerformanceIntro.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/entity/PerformanceIntro.java
@@ -1,0 +1,23 @@
+package com.pickgo.performance.performance.entity;
+
+import com.pickgo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class PerformanceIntro extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String intro_image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/entity/PerformanceSession.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/entity/PerformanceSession.java
@@ -1,0 +1,32 @@
+package com.pickgo.performance.performance.entity;
+
+import com.pickgo.global.entity.BaseEntity;
+import com.pickgo.performance.seat.entity.Seat;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class PerformanceSession extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDateTime performanceTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "performanceSession", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Seat> seats = new ArrayList<>();
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/entity/Venue.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/entity/Venue.java
@@ -1,0 +1,22 @@
+package com.pickgo.performance.performance.entity;
+
+import com.pickgo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class Venue extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/repository/PerformanceIntroRepository.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/repository/PerformanceIntroRepository.java
@@ -1,0 +1,7 @@
+package com.pickgo.performance.performance.repository;
+
+import com.pickgo.performance.performance.entity.PerformanceIntro;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceIntroRepository extends JpaRepository<PerformanceIntro, Long> {
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/repository/PerformanceRepository.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/repository/PerformanceRepository.java
@@ -1,0 +1,7 @@
+package com.pickgo.performance.performance.repository;
+
+import com.pickgo.performance.performance.entity.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/repository/PerformanceSessionRepository.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/repository/PerformanceSessionRepository.java
@@ -1,0 +1,7 @@
+package com.pickgo.performance.performance.repository;
+
+import com.pickgo.performance.performance.entity.PerformanceSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceSessionRepository extends JpaRepository<PerformanceSession, Long> {
+}

--- a/backend/src/main/java/com/pickgo/performance/performance/repository/VenueRepository.java
+++ b/backend/src/main/java/com/pickgo/performance/performance/repository/VenueRepository.java
@@ -1,0 +1,7 @@
+package com.pickgo.performance.performance.repository;
+
+import com.pickgo.performance.performance.entity.Venue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VenueRepository extends JpaRepository<Venue, Long> {
+}

--- a/backend/src/main/java/com/pickgo/performance/seat/entity/Seat.java
+++ b/backend/src/main/java/com/pickgo/performance/seat/entity/Seat.java
@@ -1,0 +1,36 @@
+package com.pickgo.performance.seat.entity;
+
+import com.pickgo.global.entity.BaseEntity;
+import com.pickgo.performance.area.entity.PerformanceArea;
+import com.pickgo.performance.performance.entity.PerformanceSession;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class Seat extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, name = "seat_row")
+    private String row;
+
+    @Column(nullable = false)
+    private Integer number;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SeatStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_session_id", nullable = false)
+    private PerformanceSession performanceSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_area_id", nullable = false)
+    private PerformanceArea performanceArea;
+}

--- a/backend/src/main/java/com/pickgo/performance/seat/entity/SeatStatus.java
+++ b/backend/src/main/java/com/pickgo/performance/seat/entity/SeatStatus.java
@@ -1,0 +1,12 @@
+package com.pickgo.performance.seat.entity;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum SeatStatus {
+    AVAILABLE("예약 가능"),
+    PENDING("예약 중"),
+    RESERVED("예약 완료");
+
+    private final String value;
+}

--- a/backend/src/main/java/com/pickgo/performance/seat/repository/SeatRepository.java
+++ b/backend/src/main/java/com/pickgo/performance/seat/repository/SeatRepository.java
@@ -1,0 +1,7 @@
+package com.pickgo.performance.seat.repository;
+
+import com.pickgo.performance.seat.entity.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+}


### PR DESCRIPTION
## 연관된 이슈
#6

## 작업 내용
- 공연 관련 entity 구현
  - performance
  - performance_intro
  - performance_session
  - venue
  - performance_area
  - seat 
- repository 구현

## 리뷰 요구사항
Seat의 row가 예약어이기 때문에 사용할 수 없어서 seat_row로 우선 작성했습니다. 의논이 필요합니다.
### 패키지 구조
venue는 좀 더 복잡한 구조에서는 분리하는게 맞는 것 같은데 저희 프로젝트에서는 간단해서 일단 공연에 포함시켰습니다. 
- performance
  - performance
    - Performance.java
    - PerformanceIntro.java
    - PerformanceSession.java
    - Venue.java
  - area
    - PerformanceArea.java
  - seat 
    - Seat.java
