### PR TITLE
소셜 로그인 구현(Kakao)

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -60,6 +60,7 @@ jobs:
           USER_TOKEN: ${{ secrets.USER_TOKEN }}
           EXPIRED_TOKEN: ${{ secrets.EXPIRED_TOKEN }}
           KOPIS_APIKEY: ${{ secrets.KOPIS_APIKEY }}
+          KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,9 +37,14 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
+	// Jwt
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
+	// Kakao login
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/pickgo/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/pickgo/domain/member/entity/Member.java
@@ -47,6 +47,7 @@ public class Member extends BaseEntity {
 
 	private String profile;
 
+	@Setter
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private SocialProvider socialProvider;

--- a/backend/src/main/java/com/pickgo/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/pickgo/domain/member/service/MemberService.java
@@ -46,7 +46,7 @@ public class MemberService {
 		}
 
 		Member member = request.toEntity(passwordEncoder, profile);
-		member = memberRepository.save(member);
+		saveEntity(member);
 
 		return MemberDetailResponse.from(member);
 	}
@@ -105,12 +105,16 @@ public class MemberService {
 		return MemberDetailResponse.from(member);
 	}
 
-	private Member getEntity(UUID id) {
+	public Member saveEntity(Member member) {
+		return memberRepository.save(member);
+	}
+
+	public Member getEntity(UUID id) {
 		return memberRepository.findById(id)
 			.orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
 	}
 
-	private Member getEntity(String email) {
+	public Member getEntity(String email) {
 		return memberRepository.findByEmail(email)
 			.orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
 	}

--- a/backend/src/main/java/com/pickgo/domain/oauth/kakao/controller/KakaoController.java
+++ b/backend/src/main/java/com/pickgo/domain/oauth/kakao/controller/KakaoController.java
@@ -1,0 +1,37 @@
+package com.pickgo.domain.oauth.kakao.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+import com.pickgo.domain.oauth.kakao.service.KakaoService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/oauth/kakao")
+@RequiredArgsConstructor
+@Tag(name = "Kakao API", description = "Kakao API 엔드포인트")
+public class KakaoController {
+
+	private final KakaoService kakaoService;
+
+	@GetMapping("/login")
+	public RedirectView redirectToKakaoLogin() {
+		return kakaoService.redirectToKakaoLogin();
+	}
+
+	@GetMapping("/login/redirect")
+	public RedirectView login(
+		@RequestParam("code") String code,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		return kakaoService.login(code, request, response);
+	}
+}

--- a/backend/src/main/java/com/pickgo/domain/oauth/kakao/dto/KakaoToken.java
+++ b/backend/src/main/java/com/pickgo/domain/oauth/kakao/dto/KakaoToken.java
@@ -1,0 +1,24 @@
+package com.pickgo.domain.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoToken(
+	@JsonProperty("token_type")
+	String tokenType,
+
+	@JsonProperty("access_token")
+	String accessToken,
+
+	@JsonProperty("refresh_token")
+	String refreshToken,
+
+	@JsonProperty("expires_in")
+	Long expiresIn,
+
+	@JsonProperty("scope")
+	String agreeScope, // 동의한 사용자 정보 제공 목록 (ex: nickname, profile, email 등)
+
+	@JsonProperty("refresh_token_expires_in")
+	Long refreshTokenExpiresIn
+) {
+}

--- a/backend/src/main/java/com/pickgo/domain/oauth/kakao/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/pickgo/domain/oauth/kakao/dto/KakaoUserInfo.java
@@ -1,0 +1,42 @@
+package com.pickgo.domain.oauth.kakao.dto;
+
+import static com.pickgo.domain.member.entity.enums.Authority.*;
+import static com.pickgo.domain.member.entity.enums.SocialProvider.*;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pickgo.domain.member.entity.Member;
+
+public record KakaoUserInfo(
+	@JsonProperty("id") Long id,
+	@JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+	public record KakaoAccount(
+		String email,
+		Profile profile
+	) {
+		public record Profile(
+			String nickname,
+			@JsonProperty("profile_image_url") String profileImageUrl
+		) {
+		}
+	}
+
+	public Member toEntity(String profile) {
+		String profileImage = kakaoAccount().profile().profileImageUrl();
+		if (profileImage == null) {
+			profileImage = profile;
+		}
+
+		return Member.builder()
+			.id(UUID.randomUUID())
+			.email(kakaoAccount().email())
+			.password("")
+			.nickname(kakaoAccount().profile().nickname())
+			.authority(USER)
+			.socialProvider(KAKAO)
+			.profile(profileImage)
+			.build();
+	}
+}

--- a/backend/src/main/java/com/pickgo/domain/oauth/kakao/service/KakaoService.java
+++ b/backend/src/main/java/com/pickgo/domain/oauth/kakao/service/KakaoService.java
@@ -1,0 +1,149 @@
+package com.pickgo.domain.oauth.kakao.service;
+
+import static com.pickgo.domain.member.entity.enums.SocialProvider.*;
+import static com.pickgo.global.response.RsCode.*;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.view.RedirectView;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.pickgo.domain.auth.service.TokenService;
+import com.pickgo.domain.member.entity.Member;
+import com.pickgo.domain.member.service.MemberService;
+import com.pickgo.domain.oauth.kakao.dto.KakaoToken;
+import com.pickgo.domain.oauth.kakao.dto.KakaoUserInfo;
+import com.pickgo.global.exception.BusinessException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+	@Value("${custom.oauth.kakao.redirect-uri}")
+	private String redirectUri;
+
+	@Value("${custom.oauth.kakao.api-key}")
+	private String apiKey;
+
+	@Value("${custom.oauth.kakao.authorize-uri}")
+	private String authorizeUri;
+
+	@Value("${custom.oauth.kakao.token-uri}")
+	private String tokenUri;
+
+	@Value("${custom.oauth.kakao.user-info-uri}")
+	private String userInfoUri;
+
+	@Value("${custom.member.profile}")
+	private String profile;
+
+	private final RestTemplate restTemplate;
+	private final TokenService tokenService;
+	private final MemberService memberService;
+
+	public RedirectView redirectToKakaoLogin() {
+		String kakaoAuthUrl = UriComponentsBuilder.fromUriString(authorizeUri)
+			.queryParam("client_id", apiKey)
+			.queryParam("redirect_uri", redirectUri)
+			.queryParam("response_type", "code")
+			.build()
+			.toString();
+
+		return new RedirectView(kakaoAuthUrl);
+	}
+
+	@Transactional
+	public RedirectView login(String code, HttpServletRequest request, HttpServletResponse response) {
+		KakaoToken kakaoToken = getToken(code);
+		KakaoUserInfo userInfo = getUserInfo(kakaoToken.accessToken());
+
+		Member member = getOrCreateMember(userInfo);
+		tokenService.createRefreshToken(member, response);
+
+		String origin = getOriginFromRequest(request);
+		String homeUrl = UriComponentsBuilder.fromUriString(origin)
+			.build()
+			.toString();
+
+		return new RedirectView(homeUrl);
+	}
+
+	private KakaoToken getToken(String code) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", "authorization_code");
+		body.add("client_id", apiKey);
+		body.add("redirect_uri", redirectUri);
+		body.add("code", code);
+
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+		ResponseEntity<KakaoToken> response = restTemplate.postForEntity(
+			tokenUri,
+			request,
+			KakaoToken.class
+		);
+
+		return response.getBody();
+	}
+
+	private KakaoUserInfo getUserInfo(String accessToken) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		headers.set("Authorization", "Bearer " + accessToken);
+
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+		ResponseEntity<KakaoUserInfo> response = restTemplate.postForEntity(
+			userInfoUri,
+			request,
+			KakaoUserInfo.class
+		);
+
+		return response.getBody();
+	}
+
+	private Member getOrCreateMember(KakaoUserInfo userInfo) {
+		try {
+			Member member = memberService.getEntity(userInfo.kakaoAccount().email());
+			member.setSocialProvider(KAKAO);
+			return member;
+		} catch (BusinessException e) {
+			Member newMember = userInfo.toEntity(profile);
+			return memberService.saveEntity(newMember);
+		}
+	}
+
+	private String getOriginFromRequest(HttpServletRequest request) {
+		String origin = request.getHeader("Origin");
+		if (origin != null)
+			return origin;
+
+		String referer = request.getHeader("Referer");
+		if (referer == null)
+			throw new BusinessException(BAD_REQUEST);
+
+		URI uri = URI.create(referer);
+		String result = uri.getScheme() + "://" + uri.getHost();
+		if (uri.getPort() != -1) {
+			result += ":" + uri.getPort();
+		}
+		return result;
+	}
+}

--- a/backend/src/main/java/com/pickgo/global/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/pickgo/global/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.pickgo.global.config;
+
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Primary
+	@Bean(name = "defaultClient")
+	public RestTemplate defaultRestTemplate(RestTemplateBuilder builder) {
+		return builder
+			.connectTimeout(Duration.ofSeconds(3))
+			.readTimeout(Duration.ofSeconds(5))
+			.build();
+	}
+}
+

--- a/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
@@ -43,6 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			|| request.getRequestURI().equals("/api/members")
 			|| request.getRequestURI().equals("/api/members/login")
 			|| request.getRequestURI().startsWith("/api/examples")
+			|| request.getRequestURI().startsWith("/api/oauth")
 			|| request.getRequestURI().startsWith("/swagger-ui")
 			|| request.getRequestURI().startsWith("/v3/api-docs")
 		) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -45,5 +45,14 @@ custom:
   member:
     profile: ${MEMBER_PROFILE:https://url.kr/estdgi}
 
+  oauth:
+    kakao:
+      api-key: ${KAKAO_API_KEY}
+      redirect-uri: ${KAKAO_LOGIN_REDIRECT_URI:http://localhost:8080/api/oauth/kakao/login/redirect}
+      authorize-uri: ${KAKAO_AUTHORIZE_URI:https://kauth.kakao.com/oauth/authorize}
+      token-uri: ${KAKAO_TOKEN_URI:https://kauth.kakao.com/oauth/token}
+      user-info-uri: ${KAKAO_USER_INFO_URI:https://kapi.kakao.com/v2/user/me}
+
 kopis:
   apikey: ${KOPIS_APIKEY}
+

--- a/backend/src/test/java/com/pickgo/oauth/KakaoServiceTest.java
+++ b/backend/src/test/java/com/pickgo/oauth/KakaoServiceTest.java
@@ -1,0 +1,107 @@
+package com.pickgo.oauth;
+
+import static com.pickgo.domain.member.entity.enums.SocialProvider.*;
+import static com.pickgo.global.response.RsCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.view.RedirectView;
+
+import com.pickgo.domain.auth.service.TokenService;
+import com.pickgo.domain.member.entity.Member;
+import com.pickgo.domain.member.service.MemberService;
+import com.pickgo.domain.oauth.kakao.dto.KakaoToken;
+import com.pickgo.domain.oauth.kakao.dto.KakaoUserInfo;
+import com.pickgo.domain.oauth.kakao.service.KakaoService;
+import com.pickgo.global.exception.BusinessException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoServiceTest {
+
+	@Mock
+	private RestTemplate restTemplate;
+	@Mock
+	private TokenService tokenService;
+	@Mock
+	private MemberService memberService;
+	@Mock
+	private HttpServletRequest request;
+	@Mock
+	private HttpServletResponse response;
+
+	@InjectMocks
+	private KakaoService kakaoService;
+
+	private final String email = "kakao@example.com";
+	private final String frontendUrl = "http://localhost:3000";
+
+	private final UUID userId = UUID.randomUUID();
+	private final KakaoUserInfo.KakaoAccount.Profile kakaoProfile = new KakaoUserInfo.KakaoAccount.Profile("닉네임",
+		"http://profile.img");
+	private final KakaoUserInfo.KakaoAccount kakaoAccount = new KakaoUserInfo.KakaoAccount(email, kakaoProfile);
+	private final KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(1L, kakaoAccount);
+
+	private Member getMockMember() {
+		return Member.builder()
+			.id(userId)
+			.email(email)
+			.password("")
+			.nickname(kakaoProfile.nickname())
+			.socialProvider(KAKAO)
+			.build();
+	}
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(kakaoService, "tokenUri", "https://kauth.kakao.com/oauth/token");
+		ReflectionTestUtils.setField(kakaoService, "apiKey", "test-api-key");
+		ReflectionTestUtils.setField(kakaoService, "redirectUri",
+			"http://localhost:8080/api/oauth/kakao/login/redirect");
+		ReflectionTestUtils.setField(kakaoService, "userInfoUri", "https://kapi.kakao.com/v2/user/me");
+		ReflectionTestUtils.setField(kakaoService, "authorizeUri", "https://kauth.kakao.com/oauth/authorize");
+		ReflectionTestUtils.setField(kakaoService, "profile", "https://default.profile.img");
+	}
+
+	@Test
+	@DisplayName("카카오 로그인 성공 시 리다이렉트 반환 및 토큰 발급")
+	void kakaoLogin_success() {
+		// given
+		String code = "auth-code";
+		String accessToken = "access-token";
+		Member member = getMockMember();
+		KakaoToken kakaoToken = new KakaoToken(accessToken, "bearer", "refresh", 3600L, null, 86400L);
+
+		when(restTemplate.postForEntity(anyString(), any(), eq(KakaoToken.class)))
+			.thenReturn(ResponseEntity.ok(kakaoToken)); // kakao token 요청 응답
+
+		when(restTemplate.postForEntity(anyString(), any(), eq(KakaoUserInfo.class)))
+			.thenReturn(ResponseEntity.ok(kakaoUserInfo)); // kakao user info 응답
+
+		when(memberService.getEntity(email)).thenThrow(new BusinessException(MEMBER_NOT_FOUND));
+		when(memberService.saveEntity(any(Member.class))).thenReturn(member); // 기존 회원 없음 → 신규 저장
+
+		when(request.getHeader("Origin")).thenReturn(frontendUrl); // 요청 헤더에 origin 정보 존재
+
+		// when
+		RedirectView redirectView = kakaoService.login(code, request, response);
+
+		// then
+		assertThat(redirectView.getUrl()).isEqualTo(frontendUrl);
+		verify(tokenService).createRefreshToken(eq(member), eq(response));
+	}
+}


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호
#22 

## 작업 내용
- memberService 리팩토링
- kakao 로그인 구현 및 테스트 코드 작성

## 스크린샷 (선택)

시퀀스
![image](https://github.com/user-attachments/assets/6b082eba-37ba-477a-aa93-d8c8f5cf1821)

## 테스트 사항
- [x] 카카오 로그인 페이지 접속 되는지 확인
  - 직접 url에 입력해서 확인했습니다.
- [x] 카카오 로그인 요청 시 로그인 처리 후 리다이렉트 되면서 쿠키가 브라우저에 전달되는지 확인
  - 프론트 서버 도메인을 추출해서 해당 도메인의 루트 경로로 리다이렉트하기 때문에 프론트 서버 띄워서도 테스트 해보았습니다.
  - 브라우저만으로도 쿠키는 받을 수 있으나 도메인을 추출할 수 없어서 bad request 응답을 받습니다.
- [x] 그 외 토큰 발급, 사용자 조회 시 응답이 제대로 오는지
  - postman으로 테스트했습니다.
- [x] 서비스 로직 단위테스트

## 체크 리스트

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)
서버에서 리다이렉트하는 방식으로 구현해서 Postman이나 브라우저 자체로는 전체적인 테스트가 안됩니다.
개별 테스트는 postman으로 했고, 전체 테스트는 프론트 코드 작성해서 해봤습니다.

* 브라우저 정책에 따라 쿠키 secure=false 인 경우, sameSite를 Lax/Strict로 바꿔야지만 쿠키를 받을 수 있습니다.(크롬 등)
배포 시에는 쿠키 secure=true이기 때문에 상관 없다고 합니다.