### PR TITLE
feat: 프로필 사진 업로드 기능 구현

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -60,6 +60,9 @@ jobs:
           USER_TOKEN: ${{ secrets.USER_TOKEN }}
           EXPIRED_TOKEN: ${{ secrets.EXPIRED_TOKEN }}
           KOPIS_APIKEY: ${{ secrets.KOPIS_APIKEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
 
       - name: Publish Unit Test Results

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+	implementation("software.amazon.awssdk:s3:2.31.32")
 
 	// Jwt
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'

--- a/backend/src/main/java/com/pickgo/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/pickgo/domain/member/controller/MemberController.java
@@ -3,13 +3,7 @@ package com.pickgo.domain.member.controller;
 import static com.pickgo.global.response.RsCode.*;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.pickgo.domain.member.dto.LoginRequest;
 import com.pickgo.domain.member.dto.LoginResponse;
@@ -25,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/members")
@@ -89,5 +84,15 @@ public class MemberController {
 	) {
 		memberService.updatePassword(principal.id(), request);
 		return RsData.from(SUCCESS);
+	}
+
+	@Operation(summary = "프로필 이미지 수정")
+	@PutMapping("/me/profile")
+	public RsData<String> updateProfileImage(
+			@AuthenticationPrincipal MemberPrincipal principal,
+			@RequestParam MultipartFile image
+	) {
+		String imageUrl = memberService.updateProfileImage(principal.id(), image);
+		return RsData.from(SUCCESS, imageUrl);
 	}
 }

--- a/backend/src/main/java/com/pickgo/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/pickgo/domain/member/entity/Member.java
@@ -45,6 +45,7 @@ public class Member extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private Authority authority;
 
+	@Setter
 	private String profile;
 
 	@Setter

--- a/backend/src/main/java/com/pickgo/global/response/RsCode.java
+++ b/backend/src/main/java/com/pickgo/global/response/RsCode.java
@@ -19,7 +19,11 @@ public enum RsCode {
 	// Member
 	MEMBER_LOGIN_FAILED(RsConstant.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
 	MEMBER_NOT_FOUND(RsConstant.NOT_FOUND, "존재하지 않는 유저입니다."),
-	MEMBER_ALREADY_EXISTS(RsConstant.BAD_REQUEST, "이미 존재하는 유저입니다.");
+	MEMBER_ALREADY_EXISTS(RsConstant.BAD_REQUEST, "이미 존재하는 유저입니다."),
+
+	// S3
+	FILE_UPLOAD_FAILED(RsConstant.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+	FILE_DELETE_FAILED(RsConstant.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");
 
 	private final Integer code;
 	private final String message;

--- a/backend/src/main/java/com/pickgo/global/s3/AwsS3Uploader.java
+++ b/backend/src/main/java/com/pickgo/global/s3/AwsS3Uploader.java
@@ -1,0 +1,64 @@
+package com.pickgo.global.s3;
+
+import com.pickgo.global.exception.BusinessException;
+import com.pickgo.global.response.RsCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Profile("!test")
+public class AwsS3Uploader implements S3Uploader {
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Override
+    public String upload(MultipartFile file, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        System.out.println(fileName);
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        try {
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new BusinessException(RsCode.FILE_UPLOAD_FAILED);
+        }
+
+        return "https://%s.s3.%s.amazonaws.com/%s".formatted(bucketName, region, fileName);
+    }
+
+    @Override
+    public void delete(String url) {
+        String key = URI.create(url).getPath().substring(1);
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        try {
+            s3Client.deleteObject(deleteRequest);
+        } catch (Exception e) {
+            throw new BusinessException(RsCode.FILE_DELETE_FAILED);
+        }
+    }
+}

--- a/backend/src/main/java/com/pickgo/global/s3/AwsS3Uploader.java
+++ b/backend/src/main/java/com/pickgo/global/s3/AwsS3Uploader.java
@@ -30,7 +30,7 @@ public class AwsS3Uploader implements S3Uploader {
     @Override
     public String upload(MultipartFile file, String dirName) {
         String fileName = dirName + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
-        System.out.println(fileName);
+
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileName)

--- a/backend/src/main/java/com/pickgo/global/s3/MockS3Uploader.java
+++ b/backend/src/main/java/com/pickgo/global/s3/MockS3Uploader.java
@@ -1,0 +1,19 @@
+package com.pickgo.global.s3;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@Profile("test")
+public class MockS3Uploader implements S3Uploader {
+
+    @Override
+    public String upload(MultipartFile file, String dirName) {
+        return "https://mock-s3.com/" + dirName + "/" + file.getOriginalFilename();
+    }
+
+    @Override
+    public void delete(String url) {
+    }
+}

--- a/backend/src/main/java/com/pickgo/global/s3/S3Config.java
+++ b/backend/src/main/java/com/pickgo/global/s3/S3Config.java
@@ -1,0 +1,40 @@
+package com.pickgo.global.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+import java.util.Optional;
+
+@Configuration
+@Profile("!test")
+public class S3Config {
+    @Value("${aws.credentials.access_key}")
+    private Optional<String> accessKey;
+
+    @Value("${aws.credentials.secret_key}")
+    private Optional<String> secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(region));
+
+        // 개발 환경 시 credential 세팅
+        if (accessKey.isPresent() && secretKey.isPresent()) {
+            AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey.get(), secretKey.get());
+            builder.credentialsProvider(StaticCredentialsProvider.create(credentials));
+        }
+
+        return builder.build();
+    }
+}

--- a/backend/src/main/java/com/pickgo/global/s3/S3Uploader.java
+++ b/backend/src/main/java/com/pickgo/global/s3/S3Uploader.java
@@ -1,0 +1,9 @@
+package com.pickgo.global.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Uploader {
+    String upload(MultipartFile file, String dirName);
+
+    void delete(String url);
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -16,3 +16,11 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
+
+aws:
+  s3:
+    bucket: team02-pickgo-dev-bucket
+  region: ${AWS_REGION}
+  credentials:
+    access_key: ${AWS_ACCESS_KEY_ID}
+    secret_key: ${AWS_SECRET_ACCESS_KEY}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -15,3 +15,8 @@ logging:
     org.hibernate.orm.jdbc.bind: INFO
     org.hibernate.orm.jdbc.extract: INFO
     org.springframework.transaction.interceptor: INFO
+
+aws:
+  s3:
+    bucket: team02-pickgo-prod-bucket
+  region: ${AWS_REGION}

--- a/backend/src/test/java/com/pickgo/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/pickgo/member/MemberControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -58,6 +59,7 @@ public class MemberControllerTest {
 			.email(testEmail)
 			.password(passwordEncoder.encode(testPassword))
 			.nickname(testNickname)
+			.profile("profile.jpg")
 			.authority(USER)
 			.socialProvider(NONE)
 			.build();
@@ -150,5 +152,27 @@ public class MemberControllerTest {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value(SUCCESS.getCode()));
+	}
+
+	@Test
+	@DisplayName("프로필 이미지 수정 성공")
+	void updateProfileImage_성공() throws Exception {
+		MockMultipartFile profileImage = new MockMultipartFile(
+				"image",
+				"newProfile.jpg",
+				MediaType.IMAGE_JPEG_VALUE,
+				"fake-image-content".getBytes()
+		);
+
+		mockMvc.perform(multipart("/api/members/me/profile")
+						.file(profileImage)
+						.with(request -> {
+							request.setMethod("PUT");
+							return request;
+						})
+						.header("Authorization", "Bearer " + token.userToken))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+				.andExpect(jsonPath("$.data").value("https://mock-s3.com/profile/newProfile.jpg"));
 	}
 }


### PR DESCRIPTION
## 연관된 이슈
close #23 

## 작업 내용
- s3 연동
- 프로필 업로드 기능 구현

## 스크린샷 (선택)
프로필 변경
![스크린샷 2025-05-01 170506](https://github.com/user-attachments/assets/19f09e04-716a-4a02-a35a-171be8ec47f9)

프로필 이미지가 빈 값이면 기본 이미지로 변경
![스크린샷 2025-05-01 170836](https://github.com/user-attachments/assets/6f9013f1-71ba-403c-9682-8e6da2e67e95)

## 리뷰 요구사항 (선택)
개발 환경에서 S3에 접근하기 위해서 환경변수로 aws 관련 설장이 필요합니다.

