### PR TITLE
조회수 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,54 +1,55 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
-	implementation("software.amazon.awssdk:s3:2.31.32")
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+    implementation 'software.amazon.awssdk:s3:2.31.32'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	// Jwt
-	implementation 'io.jsonwebtoken:jjwt:0.12.6'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
 
-	// Kakao login
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // Kakao login
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
-	systemProperty 'spring.profiles.active', 'test'
+    useJUnitPlatform()
+    systemProperty 'spring.profiles.active', 'test'
 }

--- a/backend/src/main/java/com/pickgo/domain/post/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/pickgo/domain/post/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import com.pickgo.domain.post.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -71,4 +72,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                 AND p.isPublished = true
             """)
     Optional<Post> findByIdWithAll(Long id);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.views = p.views + :viewCount WHERE p.id = :id")
+    void updateViewCount(long id, long viewCount);
 }

--- a/backend/src/main/java/com/pickgo/global/redis/RedisConfig.java
+++ b/backend/src/main/java/com/pickgo/global/redis/RedisConfig.java
@@ -1,0 +1,21 @@
+package com.pickgo.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/backend/src/main/java/com/pickgo/global/scheduler/ViewCountScheduler.java
+++ b/backend/src/main/java/com/pickgo/global/scheduler/ViewCountScheduler.java
@@ -1,0 +1,47 @@
+package com.pickgo.global.scheduler;
+
+import com.pickgo.domain.post.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ViewCountScheduler {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final PostRepository postRepository;
+
+    // 3분 간격으로 DB에 조회수 반영
+    @Transactional
+    @Scheduled(fixedRate = 180_000)
+    public void updateViewCounts() {
+        Set<String> keys = redisTemplate.keys("view_count:*");
+
+        if (keys.isEmpty()) {
+            return;
+        }
+
+        for (String key : keys) {
+            String[] parts = key.split(":");
+            if (parts.length != 2) {
+                continue;
+            }
+
+            long id = Long.parseLong(parts[1]);
+            String value = redisTemplate.opsForValue().get(key);
+            if (value == null) {
+                continue;
+            }
+
+            long viewCount = Long.parseLong(value);
+            postRepository.updateViewCount(id, viewCount);
+
+            redisTemplate.delete(key);
+        }
+
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,6 +27,11 @@ spring:
       hibernate:
         default_batch_fetch_size: 100
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
 custom:
   jwt:
     issuer: ${JWT_ISSUER}


### PR DESCRIPTION
## 연관된 이슈
close #54

## 작업 내용
- redis 연동
- 조회수 기능 구현
  - 중복 체크: 회원(id), 비회원(ip) 기반으로 조회 이력 redis에 저장 (24시간 ttl)
  - post 별로 redis에 조회수 저장하여 3분마다 DB에 반영  
- 테스트 작성

## 스크린샷 (선택)
조회수와 조회 이력 저장
![스크린샷 2025-05-07 161442](https://github.com/user-attachments/assets/ad09a640-ae3c-4ced-b9b5-b39133a3a1e8)
3분 뒤 조회수 DB 반영
![스크린샷 2025-05-07 161601](https://github.com/user-attachments/assets/c153a7b7-443f-4ed6-bdd5-a1bd8cba3d58)

