### PR TITLE
이메일 인증 및 예매 메일 전송 구현

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -72,6 +72,8 @@ jobs:
           KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
           TOSS_PAYMENT_CLIENT_KEY: ${{ secrets.TOSS_PAYMENT_CLIENT_KEY }}
           TOSS_PAYMENT_SECRET_KEY: ${{ secrets.TOSS_PAYMENT_SECRET_KEY }}
+          EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+          EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
           REDIS_PASSWORD: ${{secrets.REDIS_PASSWORD}}
 
       - name: Publish Unit Test Results

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'software.amazon.awssdk:s3:2.31.32'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/backend/src/main/java/com/pickgo/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/pickgo/domain/member/member/controller/MemberController.java
@@ -98,7 +98,7 @@ public class MemberController {
     }
 
     @Operation(summary = "프로필 이미지 수정")
-    @PutMapping("/me/profile")
+    @PutMapping(value = "/me/profile", consumes = "multipart/form-data")
     public RsData<String> updateProfileImage(
             @AuthenticationPrincipal MemberPrincipal principal,
             @RequestParam MultipartFile image

--- a/backend/src/main/java/com/pickgo/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/pickgo/domain/member/member/controller/MemberController.java
@@ -1,32 +1,19 @@
 package com.pickgo.domain.member.member.controller;
 
-import static com.pickgo.global.response.RsCode.*;
-
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
-import com.pickgo.domain.member.member.dto.LoginRequest;
-import com.pickgo.domain.member.member.dto.LoginResponse;
-import com.pickgo.domain.member.member.dto.MemberCreateRequest;
-import com.pickgo.domain.member.member.dto.MemberDetailResponse;
-import com.pickgo.domain.member.member.dto.MemberPasswordUpdateRequest;
-import com.pickgo.domain.member.member.dto.MemberPrincipal;
-import com.pickgo.domain.member.member.dto.MemberUpdateRequest;
+import com.pickgo.domain.member.member.dto.*;
+import com.pickgo.domain.member.member.service.EmailAuthService;
 import com.pickgo.domain.member.member.service.MemberService;
 import com.pickgo.global.response.RsData;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.pickgo.global.response.RsCode.EMAIL_VERIFICATION_FAILED;
+import static com.pickgo.global.response.RsCode.SUCCESS;
 
 @RestController
 @RequestMapping("/api/members")
@@ -35,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
     private final MemberService memberService;
+    private final EmailAuthService emailAuthService;
 
     @Operation(summary = "회원가입")
     @PostMapping
@@ -42,11 +30,27 @@ public class MemberController {
         return RsData.from(SUCCESS, memberService.save(request));
     }
 
+    @Operation(summary = "인증 이메일 요청")
+    @PostMapping("/email/send-code")
+    public RsData<?> sendCode(@RequestParam String email) {
+        emailAuthService.sendCode(email);
+        return RsData.from(SUCCESS);
+    }
+
+    @Operation(summary = "이메일 인증 코드 검증")
+    @PostMapping("/email/verify-code")
+    public RsData<?> verifyEmailCode(@RequestParam String email, @RequestParam String code) {
+        boolean verified = emailAuthService.verifyCode(email, code);
+        return verified
+                ? RsData.from(SUCCESS)
+                : RsData.from(EMAIL_VERIFICATION_FAILED);
+    }
+
     @Operation(summary = "로그인")
     @PostMapping("/login")
     public RsData<LoginResponse> login(
-        @RequestBody LoginRequest request,
-        HttpServletResponse response
+            @RequestBody LoginRequest request,
+            HttpServletResponse response
     ) {
         return RsData.from(SUCCESS, memberService.login(request, response));
     }
@@ -61,8 +65,8 @@ public class MemberController {
     @Operation(summary = "회원탈퇴")
     @DeleteMapping("/me")
     public RsData<?> signout(
-        @AuthenticationPrincipal MemberPrincipal principal,
-        HttpServletResponse response
+            @AuthenticationPrincipal MemberPrincipal principal,
+            HttpServletResponse response
     ) {
         memberService.delete(principal.id(), response);
         return RsData.from(SUCCESS);
@@ -77,8 +81,8 @@ public class MemberController {
     @Operation(summary = "내 정보 수정")
     @PutMapping("/me")
     public RsData<MemberDetailResponse> updateMyInfo(
-        @AuthenticationPrincipal MemberPrincipal principal,
-        @RequestBody MemberUpdateRequest request
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @RequestBody MemberUpdateRequest request
     ) {
         return RsData.from(SUCCESS, memberService.updateMyInfo(principal.id(), request));
     }
@@ -86,8 +90,8 @@ public class MemberController {
     @Operation(summary = "비밀번호 변경")
     @PutMapping("/me/password")
     public RsData<?> updatePassword(
-        @AuthenticationPrincipal MemberPrincipal principal,
-        @RequestBody MemberPasswordUpdateRequest request
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @RequestBody MemberPasswordUpdateRequest request
     ) {
         memberService.updatePassword(principal.id(), request);
         return RsData.from(SUCCESS);
@@ -96,8 +100,8 @@ public class MemberController {
     @Operation(summary = "프로필 이미지 수정")
     @PutMapping("/me/profile")
     public RsData<String> updateProfileImage(
-        @AuthenticationPrincipal MemberPrincipal principal,
-        @RequestParam MultipartFile image
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @RequestParam MultipartFile image
     ) {
         String imageUrl = memberService.updateProfileImage(principal.id(), image);
         return RsData.from(SUCCESS, imageUrl);

--- a/backend/src/main/java/com/pickgo/domain/member/member/entity/Member.java
+++ b/backend/src/main/java/com/pickgo/domain/member/member/entity/Member.java
@@ -1,28 +1,15 @@
 package com.pickgo.domain.member.member.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import com.pickgo.domain.member.member.entity.enums.Authority;
 import com.pickgo.domain.member.member.entity.enums.SocialProvider;
 import com.pickgo.domain.reservation.entity.Reservation;
 import com.pickgo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,6 +34,7 @@ public class Member extends BaseEntity {
     private String nickname;
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
+    @Setter
     private Authority authority;
     @Setter
     private String profile;

--- a/backend/src/main/java/com/pickgo/domain/member/member/service/EmailAuthService.java
+++ b/backend/src/main/java/com/pickgo/domain/member/member/service/EmailAuthService.java
@@ -14,7 +14,7 @@ public class EmailAuthService {
     private final EmailService emailService;
     private final StringRedisTemplate redisTemplate;
 
-    private static final Duration EXPIRE_DURATION = Duration.ofMinutes(10);
+    private static final Duration EXPIRE_DURATION = Duration.ofMinutes(5);
 
     public void sendCode(String email) {
         String code = generateCode();

--- a/backend/src/main/java/com/pickgo/domain/member/member/service/EmailAuthService.java
+++ b/backend/src/main/java/com/pickgo/domain/member/member/service/EmailAuthService.java
@@ -1,0 +1,62 @@
+package com.pickgo.domain.member.member.service;
+
+import com.pickgo.global.email.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailAuthService {
+    private final EmailService emailService;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final Duration EXPIRE_DURATION = Duration.ofMinutes(10);
+
+    public void sendCode(String email) {
+        String code = generateCode();
+
+        // redis 저장 ttl 5분
+        redisTemplate.opsForValue().set(getRedisKey(email), code, EXPIRE_DURATION);
+
+        // 이메일 전송
+        emailService.sendEmail(email, "[pickgo] 이메일 인증 코드", "인증 코드: " + code);
+    }
+
+    public boolean verifyCode(String email, String code) {
+        String key = getRedisKey(email);
+        String savedCode = redisTemplate.opsForValue().get(key);
+
+        if (code.equals(savedCode)) {
+            redisTemplate.delete(key);
+            redisTemplate.opsForValue().set(getVerifiedKey(email), "true", EXPIRE_DURATION);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isVerified(String email) {
+        String key = getVerifiedKey(email);
+        String verified = redisTemplate.opsForValue().get(key);
+        if ("true".equals(verified)) {
+            redisTemplate.delete(key);
+            return true;
+        }
+        return false;
+    }
+
+    private String generateCode() {
+        return String.format("%06d", new Random().nextInt(999999));
+    }
+
+    private String getRedisKey(String email) {
+        return "email:verify:" + email;
+    }
+
+    private String getVerifiedKey(String email) {
+        return "email:verify:success:" + email;
+    }
+}

--- a/backend/src/main/java/com/pickgo/domain/member/member/service/MemberService.java
+++ b/backend/src/main/java/com/pickgo/domain/member/member/service/MemberService.java
@@ -20,6 +20,7 @@ import com.pickgo.domain.auth.token.service.TokenService;
 import com.pickgo.domain.log.enums.ActionType;
 import com.pickgo.domain.member.member.dto.*;
 import com.pickgo.domain.member.member.entity.Member;
+import com.pickgo.domain.member.member.entity.enums.Authority;
 import com.pickgo.domain.member.member.repository.MemberRepository;
 import com.pickgo.global.exception.BusinessException;
 import com.pickgo.global.logging.util.LogWriter;
@@ -62,6 +63,13 @@ public class MemberService {
         logWriter.writeMemberLog(member, ActionType.MEMBER_SIGNUP, logContext);
 
         return MemberDetailResponse.from(member);
+    }
+
+    @Transactional
+    public void saveAdmin(MemberCreateRequest memberCreateRequest) {
+        Member member = memberCreateRequest.toEntity(passwordEncoder, profile);
+        member.setAuthority(Authority.ADMIN);
+        saveEntity(member);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/pickgo/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/pickgo/domain/payment/service/PaymentService.java
@@ -168,6 +168,7 @@ public class PaymentService {
             applicationEventPublisher.publishEvent(new SeatStatusChangedEvent(seat)); // 좌석 상태 변경 이벤트를 spring에 발행, 구독하고 있는 SSE리스너가 변경 감지 -> 알림 발송
         });
 
+
         // 4. 예약 메일 발송
         emailService.sendReservationEmail(reservation, payment);
 

--- a/backend/src/main/java/com/pickgo/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/pickgo/domain/payment/service/PaymentService.java
@@ -158,7 +158,7 @@ public class PaymentService {
         payment.setPaymentKey(req.paymentKey());
 
         // 2. 예약 상태 변경
-        Reservation reservation = payment.getReservation();
+        Reservation reservation = reservationRepository.findWithAllDetails(payment.getReservation().getId());
         reservation.setStatus(ReservationStatus.PAID);
 
         // 3. 좌석 상태 변경
@@ -170,7 +170,7 @@ public class PaymentService {
 
 
         // 4. 예약 메일 발송
-        emailService.sendReservationEmail(reservation, payment);
+        emailService.sendReservationEmail(reservation);
 
         LogContext logContext = logContextUtil.extract();
         logWriter.writePaymentLog(payment,ActionType.PAYMENT_COMPLETED, logContext);

--- a/backend/src/main/java/com/pickgo/domain/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/pickgo/domain/reservation/repository/ReservationRepository.java
@@ -5,6 +5,7 @@ import com.pickgo.domain.reservation.enums.ReservationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -18,5 +19,17 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByStatusAndCreatedAtBefore(ReservationStatus status, LocalDateTime createdAtBefore);
 
-    Page<Reservation> findByMemberIdAndStatusIn(UUID memberId, Collection<ReservationStatus> statuses,Pageable pageable);
+    Page<Reservation> findByMemberIdAndStatusIn(UUID memberId, Collection<ReservationStatus> statuses, Pageable pageable);
+
+    @Query("""
+                SELECT r FROM Reservation r
+                JOIN FETCH r.member m
+                JOIN FETCH r.performanceSession ps
+                JOIN FETCH ps.performance p
+                JOIN FETCH p.venue v
+                JOIN FETCH r.reservedSeats rs
+                JOIN FETCH rs.performanceArea pa
+                WHERE r.id = :id
+            """)
+    Reservation findWithAllDetails(Long id);
 }

--- a/backend/src/main/java/com/pickgo/global/email/EmailConfig.java
+++ b/backend/src/main/java/com/pickgo/global/email/EmailConfig.java
@@ -1,0 +1,65 @@
+package com.pickgo.global.email;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connection-timeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.write-timeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.smtp.starttls.required", starttlsRequired);
+        props.put("mail.smtp.connectiontimeout", connectionTimeout);
+        props.put("mail.smtp.timeout", timeout);
+        props.put("mail.smtp.writetimeout", writeTimeout);
+        return props;
+    }
+}

--- a/backend/src/main/java/com/pickgo/global/email/EmailService.java
+++ b/backend/src/main/java/com/pickgo/global/email/EmailService.java
@@ -1,0 +1,20 @@
+package com.pickgo.global.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender javaMailSender;
+
+    public void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        javaMailSender.send(message);
+    }
+}

--- a/backend/src/main/java/com/pickgo/global/email/EmailService.java
+++ b/backend/src/main/java/com/pickgo/global/email/EmailService.java
@@ -1,9 +1,15 @@
 package com.pickgo.global.email;
 
+import com.pickgo.domain.payment.entity.Payment;
+import com.pickgo.domain.reservation.entity.Reservation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,5 +22,29 @@ public class EmailService {
         message.setSubject(subject);
         message.setText(text);
         javaMailSender.send(message);
+    }
+
+    public void sendReservationEmail(Reservation reservation, Payment payment) {
+        String email = reservation.getMember().getEmail();
+        String subject = "[pickgo] 예매가 완료되었습니다";
+        StringBuilder body = new StringBuilder();
+        body.append("안녕하세요, ").append(reservation.getMember().getNickname()).append("님!\n\n");
+        body.append("예약이 성공적으로 완료되었습니다.\n\n");
+        body.append("📅 공연명: ").append(reservation.getPerformanceSession().getPerformance().getName()).append("\n");
+        LocalDateTime performanceTime = reservation.getPerformanceSession().getPerformanceTime();
+        String formatted = performanceTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분"));
+        body.append("🗓️ 공연 시간: ").append(formatted).append("\n");
+        String seats = reservation.getReservedSeats().stream()
+                .map(rs -> "%s %s %s%s".formatted(
+                        rs.getPerformanceArea().getName().getValue(),
+                        rs.getPerformanceArea().getGrade().getValue(),
+                        rs.getRow(),
+                        rs.getNumber()))
+                .collect(Collectors.joining(", "));
+        body.append("💺 좌석: ").append(seats).append("\n");
+        body.append("💳 결제 금액: ").append(payment.getAmount()).append("원\n");
+        body.append("감사합니다.");
+
+        sendEmail(email, subject, body.toString());
     }
 }

--- a/backend/src/main/java/com/pickgo/global/email/EmailService.java
+++ b/backend/src/main/java/com/pickgo/global/email/EmailService.java
@@ -1,6 +1,5 @@
 package com.pickgo.global.email;
 
-import com.pickgo.domain.payment.entity.Payment;
 import com.pickgo.domain.reservation.entity.Reservation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
@@ -24,16 +23,20 @@ public class EmailService {
         javaMailSender.send(message);
     }
 
-    public void sendReservationEmail(Reservation reservation, Payment payment) {
+    public void sendReservationEmail(Reservation reservation) {
         String email = reservation.getMember().getEmail();
         String subject = "[pickgo] 예매가 완료되었습니다";
         StringBuilder body = new StringBuilder();
-        body.append("안녕하세요, ").append(reservation.getMember().getNickname()).append("님!\n\n");
+        body.append("안녕하세요, ").append(reservation.getMember().getNickname()).append("님\n\n");
         body.append("예약이 성공적으로 완료되었습니다.\n\n");
         body.append("📅 공연명: ").append(reservation.getPerformanceSession().getPerformance().getName()).append("\n");
+
         LocalDateTime performanceTime = reservation.getPerformanceSession().getPerformanceTime();
         String formatted = performanceTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분"));
-        body.append("🗓️ 공연 시간: ").append(formatted).append("\n");
+        body.append("🗓️ 공연일시: ").append(formatted).append("\n");
+        body.append("공연장명: ").append(reservation.getPerformanceSession().getPerformance().getVenue().getName()).append("\n");
+        body.append("공연장 주소: ").append(reservation.getPerformanceSession().getPerformance().getVenue().getAddress()).append("\n");
+
         String seats = reservation.getReservedSeats().stream()
                 .map(rs -> "%s %s %s%s".formatted(
                         rs.getPerformanceArea().getName().getValue(),
@@ -42,7 +45,7 @@ public class EmailService {
                         rs.getNumber()))
                 .collect(Collectors.joining(", "));
         body.append("💺 좌석: ").append(seats).append("\n");
-        body.append("💳 결제 금액: ").append(payment.getAmount()).append("원\n");
+        body.append("💳 결제 금액: ").append(reservation.getTotalPrice()).append("원\n");
         body.append("감사합니다.");
 
         sendEmail(email, subject, body.toString());

--- a/backend/src/main/java/com/pickgo/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/pickgo/global/init/BaseInitData.java
@@ -4,12 +4,12 @@ import com.pickgo.domain.member.member.dto.MemberCreateRequest;
 import com.pickgo.domain.member.member.service.MemberService;
 import com.pickgo.domain.performance.performance.repository.PerformanceRepository;
 import com.pickgo.domain.performance.performance.service.PerformanceService;
-import com.pickgo.global.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 @RequiredArgsConstructor
@@ -18,7 +18,7 @@ public class BaseInitData {
     private final PerformanceService performanceService;
     private final PerformanceRepository performanceRepository;
     private final MemberService memberService;
-    private final EmailService emailService;
+    private final StringRedisTemplate redisTemplate;
 
 
     @Bean
@@ -34,6 +34,8 @@ public class BaseInitData {
             String password = "1234";
             String nickname = "test1234";
             if (!memberService.existsByEmail(testEmail)) {
+                // 이메일 인증 통과하도록 설정
+                redisTemplate.opsForValue().set("email:verify:success:" + testEmail, "true");
                 memberService.save(new MemberCreateRequest(testEmail, password, nickname));
                 System.out.println("회원가입이 완료되었습니다");
             }

--- a/backend/src/main/java/com/pickgo/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/pickgo/global/init/BaseInitData.java
@@ -4,6 +4,7 @@ import com.pickgo.domain.member.member.dto.MemberCreateRequest;
 import com.pickgo.domain.member.member.service.MemberService;
 import com.pickgo.domain.performance.performance.repository.PerformanceRepository;
 import com.pickgo.domain.performance.performance.service.PerformanceService;
+import com.pickgo.global.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +18,7 @@ public class BaseInitData {
     private final PerformanceService performanceService;
     private final PerformanceRepository performanceRepository;
     private final MemberService memberService;
+    private final EmailService emailService;
 
 
     @Bean

--- a/backend/src/main/java/com/pickgo/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/pickgo/global/init/BaseInitData.java
@@ -39,6 +39,13 @@ public class BaseInitData {
                 memberService.save(new MemberCreateRequest(testEmail, password, nickname));
                 System.out.println("회원가입이 완료되었습니다");
             }
+
+            String adminEmail = "admin@example.com";
+            String adminNickname = "admin1234";
+            if (!memberService.existsByEmail(adminEmail)) {
+                memberService.saveAdmin(new MemberCreateRequest(adminEmail, password, adminNickname));
+                System.out.println("관리자 회원가입이 완료되었습니다");
+            }
         };
     }
 }

--- a/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
@@ -17,8 +17,6 @@ import java.io.IOException;
 
 import static com.pickgo.global.response.RsCode.UNAUTHENTICATED;
 
-
-
 /**
  * 토큰 검증 및 사용자 인증 정보를 저장하는 필터
  */

--- a/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
@@ -1,23 +1,23 @@
 package com.pickgo.global.jwt;
 
-import static com.pickgo.global.response.RsCode.*;
-
-import java.io.IOException;
-
+import com.pickgo.global.exception.BusinessException;
+import com.pickgo.global.exception.jwt.JwtAuthenticationEntryPoint;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.pickgo.global.exception.BusinessException;
-import com.pickgo.global.exception.jwt.JwtAuthenticationEntryPoint;
+import java.io.IOException;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
+import static com.pickgo.global.response.RsCode.UNAUTHENTICATED;
+
+
 
 /**
  * 토큰 검증 및 사용자 인증 정보를 저장하는 필터
@@ -44,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (request.getRequestURI().equals("/api/tokens")
                 || request.getRequestURI().equals("/api/members")
                 || request.getRequestURI().equals("/api/members/login")
-                || request.getRequestURI().startsWith("/api/examples")
+                || request.getRequestURI().startsWith("/api/members/email")
                 || request.getRequestURI().startsWith("/api/oauth")
                 || request.getRequestURI().startsWith("/swagger-ui")
                 || request.getRequestURI().startsWith("/v3/api-docs")

--- a/backend/src/main/java/com/pickgo/global/response/RsCode.java
+++ b/backend/src/main/java/com/pickgo/global/response/RsCode.java
@@ -35,6 +35,7 @@ public enum RsCode {
     MEMBER_LOGIN_FAILED(RsConstant.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
     MEMBER_NOT_FOUND(RsConstant.NOT_FOUND, "존재하지 않는 유저입니다."),
     MEMBER_ALREADY_EXISTS(RsConstant.BAD_REQUEST, "이미 존재하는 유저입니다."),
+    EMAIL_VERIFICATION_FAILED(RsConstant.BAD_REQUEST, "인증 실패 또는 코드 만료"),
 
     // Performance
     PERFORMANCE_SESSION_NOT_FOUND(RsConstant.NOT_FOUND, "존재하지 않는 공연 회차입니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -29,8 +29,6 @@ spring:
           connection-timeout: 5000
           timeout: 5000
           write-timeout: 5000
-    auth-code-expiration-millis: 600000  # 인증 코드 유효 시간 10분
-
   
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&&allowPublicKeyRetrieval=true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,7 +14,24 @@ spring:
   output:
     ansi:
       enabled: always
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connection-timeout: 5000
+          timeout: 5000
+          write-timeout: 5000
+    auth-code-expiration-millis: 600000  # 인증 코드 유효 시간 10분
 
+  
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME}


### PR DESCRIPTION
## 연관된 이슈
close #101
> ex) #이슈번호

## 작업 내용
- gmail smtp 연동
- 이메일 인증 구현
  - 회원가입 시 이메일 입력 후 인증 요청 -> 인증 메일 발송
  - 인증 번호 입력 후 검증
  - 인증 번호 발송과 인증 여부는 redis에 저장 (ttl 5분)
- 예매 완료(결제 승인) 시 예매 메일 발송
