### PR TITLE
[refactor] jwtProvider 도메인으로부터 분리

### DIFF
--- a/backend/src/main/java/com/pickgo/domain/auth/token/service/TokenService.java
+++ b/backend/src/main/java/com/pickgo/domain/auth/token/service/TokenService.java
@@ -3,6 +3,8 @@ package com.pickgo.domain.auth.token.service;
 import static com.pickgo.global.response.RsCode.*;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -51,15 +53,18 @@ public class TokenService {
     }
 
     public String genAccessToken(Member member) {
-        return jwtProvider.generateToken(member, Duration.ofMinutes(accessTokenExpirationMinutes));
+        return jwtProvider.generateToken(member.getId().toString(), Duration.ofMinutes(accessTokenExpirationMinutes),
+                genAuthTokenClaims(member));
     }
 
     public String genRefreshToken(Member member) {
-        return jwtProvider.generateToken(member, Duration.ofMinutes(refreshTokenExpirationMinutes));
+        return jwtProvider.generateToken(member.getId().toString(), Duration.ofMinutes(refreshTokenExpirationMinutes),
+                genAuthTokenClaims(member));
     }
 
     public String genEntryToken(Member member) {
-        return jwtProvider.generateToken(member, Duration.ofMinutes(entryTokenExpirationMinutes));
+        return jwtProvider.generateToken(member.getId().toString(), Duration.ofMinutes(entryTokenExpirationMinutes),
+                genAuthTokenClaims(member));
     }
 
     private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
@@ -84,5 +89,12 @@ public class TokenService {
             .build();
 
         response.setHeader("Set-Cookie", cookie.toString());
+    }
+
+    private static Map<String, Object> genAuthTokenClaims(Member member) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("id", member.getId().toString());
+        claims.put("authority", member.getAuthority().toString());
+        return claims;
     }
 }

--- a/backend/src/main/java/com/pickgo/domain/auth/token/service/TokenService.java
+++ b/backend/src/main/java/com/pickgo/domain/auth/token/service/TokenService.java
@@ -38,7 +38,9 @@ public class TokenService {
     private boolean secure;
 
     public TokenDetailResponse createAccessToken(String refreshToken) {
-        jwtProvider.validateToken(refreshToken);
+        if (!jwtProvider.isValidToken(refreshToken)) {
+            throw new BusinessException(UNAUTHENTICATED);
+        }
 
         UUID userId = jwtProvider.getUserId(refreshToken);
         Member member = memberRepository.findById(userId)

--- a/backend/src/main/java/com/pickgo/domain/post/review/service/PostReviewService.java
+++ b/backend/src/main/java/com/pickgo/domain/post/review/service/PostReviewService.java
@@ -1,5 +1,15 @@
 package com.pickgo.domain.post.review.service;
 
+import static com.pickgo.global.response.RsCode.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.pickgo.domain.member.member.dto.MemberPrincipal;
 import com.pickgo.domain.member.member.entity.Member;
 import com.pickgo.domain.member.member.repository.MemberRepository;
@@ -14,14 +24,8 @@ import com.pickgo.domain.post.review.repository.ReviewLikeRepository;
 import com.pickgo.global.exception.BusinessException;
 import com.pickgo.global.jwt.JwtProvider;
 import com.pickgo.global.response.RsCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -74,7 +78,9 @@ public class PostReviewService {
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             try {
                 String token = authHeader.substring("Bearer ".length());
-                jwtProvider.validateToken(token);
+                if (!jwtProvider.isValidToken(token)) {
+                    throw new BusinessException(UNAUTHENTICATED);
+                }
                 Authentication auth = jwtProvider.getAuthentication(token);
                 MemberPrincipal principal = (MemberPrincipal) auth.getPrincipal();
                 return getMemberById(principal.id());

--- a/backend/src/main/java/com/pickgo/global/jwt/EntryAuthenticationFilter.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/EntryAuthenticationFilter.java
@@ -69,7 +69,7 @@ public class EntryAuthenticationFilter extends OncePerRequestFilter {
     private boolean isValidToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
             String entryAuthHeader = request.getHeader(HEADER_ENTRY_AUTH);
-            String entryToken = jwtProvider.getAccessToken(entryAuthHeader);
+            String entryToken = jwtProvider.getTokenFromHeader(entryAuthHeader);
             jwtProvider.validateToken(entryToken);
             return true;
         } catch (BusinessException e) {

--- a/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
@@ -58,7 +58,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessToken;
 
         try {
-            accessToken = jwtProvider.getAccessToken(authorizationHeader); // 헤더에서 액세스 토큰 가져옴
+            accessToken = jwtProvider.getTokenFromHeader(authorizationHeader); // 헤더에서 액세스 토큰 가져옴
             jwtProvider.validateToken(accessToken);
         } catch (BusinessException e) {
             jwtAuthenticationEntryPoint.commence(request, response, e);

--- a/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/JwtAuthenticationFilter.java
@@ -1,10 +1,11 @@
 package com.pickgo.global.jwt;
 
+import static com.pickgo.global.response.RsCode.*;
+
 import java.io.IOException;
 
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -54,17 +55,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
+        // 토큰 검증
         String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
-        String accessToken;
-
-        try {
-            accessToken = jwtProvider.getTokenFromHeader(authorizationHeader); // 헤더에서 액세스 토큰 가져옴
-            jwtProvider.validateToken(accessToken);
-        } catch (BusinessException e) {
-            jwtAuthenticationEntryPoint.commence(request, response, e);
-            return;
-        } catch (AuthenticationException e) {
-            jwtAuthenticationEntryPoint.commence(request, response, e);
+        String accessToken = jwtProvider.getTokenFromHeader(authorizationHeader);
+        if (!jwtProvider.isValidToken(accessToken)) {
+            jwtAuthenticationEntryPoint.commence(request, response, new BusinessException(UNAUTHENTICATED));
             return;
         }
 

--- a/backend/src/main/java/com/pickgo/global/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/JwtProvider.java
@@ -1,7 +1,5 @@
 package com.pickgo.global.jwt;
 
-import static com.pickgo.global.response.RsCode.*;
-
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Date;
@@ -18,7 +16,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import com.pickgo.domain.member.member.dto.MemberPrincipal;
-import com.pickgo.global.exception.BusinessException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
@@ -67,15 +64,16 @@ public class JwtProvider {
     /**
      * 유효한 토큰인지 검증 (토큰이 유효하면 사용자 인증 완료)
      **/
-    public void validateToken(String token) { // 검증하려면 token에서 "Bearer " 없어야 됨
+    public boolean isValidToken(String token) { // 검증하려면 token에서 "Bearer " 없어야 됨
         try {
             // 토큰의 서명이 올바른지, 만료되지 않았는지 확인
             Jwts.parser()
                 .verifyWith(getSecretKey()) // secret_key를 사용해서 토큰 복호화
                 .build()
                 .parseSignedClaims(token);
+            return true;
         } catch (Exception e) {
-            throw new BusinessException(UNAUTHENTICATED);
+            return false;
         }
     }
 
@@ -101,11 +99,8 @@ public class JwtProvider {
      * HTTP Header에 정의된 Bearer token 획득
      **/
     public String getTokenFromHeader(String header) {
-        if (header == null)
-            throw new BusinessException(UNAUTHENTICATED);
-        if (!header.startsWith(TOKEN_PREFIX))
-            throw new BusinessException(UNAUTHENTICATED);
-
+        if (header == null || !header.startsWith(TOKEN_PREFIX))
+            return null;
         return header.substring(TOKEN_PREFIX.length());
     }
 

--- a/backend/src/main/java/com/pickgo/global/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/pickgo/global/jwt/JwtProvider.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.crypto.SecretKey;
@@ -17,11 +18,11 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import com.pickgo.domain.member.member.dto.MemberPrincipal;
-import com.pickgo.domain.member.member.entity.Member;
 import com.pickgo.global.exception.BusinessException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -36,26 +37,31 @@ public class JwtProvider {
     /**
      * 토큰 생성
      **/
-    public String generateToken(Member member, Duration expiredAt) {
+    public String generateToken(String subject, Duration expiredAt, Map<String, Object> claims) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expiredAt.toMillis());
 
+        // 토큰 헤더 설정
         Header jwtHeader = Jwts.header().type("JWT").build();
+
+        // 서명에 사용할 Secret Key 획득
         SecretKey key = getSecretKey();
 
-        return Jwts.builder()
-            // 토큰 헤더
-            .header().add(jwtHeader).and() // 토큰 타입
-            .signWith(key, Jwts.SIG.HS256) // 암호화 방식, secret key 지정
-            // 토큰 내용(claims)
-            .subject(member.getId().toString()) // 토큰의 제목: id
-            .issuer(jwtProperties.getIssuer()) // 토큰 발급자
-            .issuedAt(now) // 토큰 발급일
-            .expiration(expiryDate) // 토큰 만료일
-            .claim("id", member.getId().toString())
-            .claim("authority", member.getAuthority().toString())
-            .compact();
-        // 토큰 서명은 헤더의 인코딩 값과 내용의 인코딩 값을 합친 후 비밀 키를 사용해 생성된 해시값
+        JwtBuilder builder = Jwts.builder()
+                .header().add(jwtHeader).and()              // 토큰 타입: JWT
+                .signWith(key, Jwts.SIG.HS256)              // 암호화 방식: HMAC-SHA256, secret key 사용
+                .subject(subject)                           // 토큰의 subject (예: 사용자 ID)
+                .issuer(jwtProperties.getIssuer())          // 토큰 발급자
+                .issuedAt(now)                              // 토큰 발급일
+                .expiration(expiryDate);                    // 토큰 만료일
+
+        // 추가로 담을 claims (id, authority 등)
+        if (claims != null && !claims.isEmpty()) {
+            builder.claims(claims);
+        }
+
+        // 토큰 서명 및 최종 문자열 생성
+        return builder.compact();
     }
 
     /**
@@ -92,15 +98,15 @@ public class JwtProvider {
     }
 
     /**
-     * HTTP Header의 Authorization에 정의된 token 획득
+     * HTTP Header에 정의된 Bearer token 획득
      **/
-    public String getAccessToken(String authorizationHeader) {
-        if (authorizationHeader == null)
+    public String getTokenFromHeader(String header) {
+        if (header == null)
             throw new BusinessException(UNAUTHENTICATED);
-        if (!authorizationHeader.startsWith(TOKEN_PREFIX))
+        if (!header.startsWith(TOKEN_PREFIX))
             throw new BusinessException(UNAUTHENTICATED);
 
-        return authorizationHeader.substring(TOKEN_PREFIX.length());
+        return header.substring(TOKEN_PREFIX.length());
     }
 
     /**

--- a/backend/src/test/java/com/pickgo/domain/auth/auth/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/pickgo/domain/auth/auth/service/TokenServiceTest.java
@@ -55,6 +55,7 @@ class TokenServiceTest {
 		given(jwtProvider.getUserId(refreshToken)).willReturn(mockMember.getId());
 		given(memberRepository.findById(mockMember.getId())).willReturn(Optional.of(mockMember));
 		given(jwtProvider.generateToken(eq(mockMember.getId().toString()), any(), eq(claims))).willReturn(accessToken);
+		given(jwtProvider.isValidToken(refreshToken)).willReturn(true);
 
 		// when
 		TokenDetailResponse response = tokenService.createAccessToken(refreshToken);
@@ -71,6 +72,7 @@ class TokenServiceTest {
 
 		given(jwtProvider.getUserId(refreshToken)).willReturn(userId);
 		given(memberRepository.findById(userId)).willReturn(Optional.empty());
+		given(jwtProvider.isValidToken(refreshToken)).willReturn(true);
 
 		// when & then
 		assertThatThrownBy(() -> tokenService.createAccessToken(refreshToken))

--- a/backend/src/test/java/com/pickgo/global/jwt/JwtProviderTest.java
+++ b/backend/src/test/java/com/pickgo/global/jwt/JwtProviderTest.java
@@ -1,6 +1,5 @@
 package com.pickgo.global.jwt;
 
-import static com.pickgo.global.response.RsCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.UUID;
@@ -24,17 +23,15 @@ class JwtProviderTest {
 
 	@Test
 	@DisplayName("유효한 토큰은 예외 없이 검증됨")
-	void validateToken_success() {
-		assertThatCode(() -> jwtProvider.validateToken(token.userToken))
+	void isValidToken_success() {
+		assertThatCode(() -> jwtProvider.isValidToken(token.userToken))
 			.doesNotThrowAnyException();
 	}
 
 	@Test
 	@DisplayName("만료된 토큰은 예외 발생")
-	void validateToken_fail_expired() {
-		assertThatThrownBy(() -> jwtProvider.validateToken(token.expiredToken))
-			.isInstanceOf(RuntimeException.class)
-			.hasMessage(UNAUTHENTICATED.getMessage());
+	void isValidToken_fail_expired() {
+		assertThat(jwtProvider.isValidToken(token.expiredToken)).isFalse();
 	}
 
 	@Test
@@ -61,18 +58,14 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("Authorization 헤더가 null이면 예외 발생")
+	@DisplayName("Authorization 헤더가 null이면 null 반환")
 	void getToken_FromHeader_fail_nullHeader() {
-		assertThatThrownBy(() -> jwtProvider.getTokenFromHeader(null))
-			.isInstanceOf(RuntimeException.class)
-			.hasMessage(UNAUTHENTICATED.getMessage());
+		assertThat(jwtProvider.getTokenFromHeader(null)).isNull();
 	}
 
 	@Test
-	@DisplayName("Authorization 헤더에 Bearer 접두어가 없으면 예외 발생")
+	@DisplayName("Authorization 헤더에 Bearer 접두어가 없으면 null 반환")
 	void getToken_FromHeader_fail_invalidPrefix() {
-		assertThatThrownBy(() -> jwtProvider.getTokenFromHeader("InvalidToken"))
-			.isInstanceOf(RuntimeException.class)
-			.hasMessage(UNAUTHENTICATED.getMessage());
+		assertThat(jwtProvider.getTokenFromHeader("InvalidToken")).isNull();
 	}
 }

--- a/backend/src/test/java/com/pickgo/global/jwt/JwtProviderTest.java
+++ b/backend/src/test/java/com/pickgo/global/jwt/JwtProviderTest.java
@@ -54,24 +54,24 @@ class JwtProviderTest {
 
 	@Test
 	@DisplayName("Authorization 헤더에서 Bearer 제거하고 액세스 토큰 추출")
-	void getAccessToken_success() {
+	void getToken_FromHeader_success() {
 		String bearer = "Bearer " + token.userToken;
-		String result = jwtProvider.getAccessToken(bearer);
+		String result = jwtProvider.getTokenFromHeader(bearer);
 		assertThat(result).isEqualTo(token.userToken);
 	}
 
 	@Test
 	@DisplayName("Authorization 헤더가 null이면 예외 발생")
-	void getAccessToken_fail_nullHeader() {
-		assertThatThrownBy(() -> jwtProvider.getAccessToken(null))
+	void getToken_FromHeader_fail_nullHeader() {
+		assertThatThrownBy(() -> jwtProvider.getTokenFromHeader(null))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessage(UNAUTHENTICATED.getMessage());
 	}
 
 	@Test
 	@DisplayName("Authorization 헤더에 Bearer 접두어가 없으면 예외 발생")
-	void getAccessToken_fail_invalidPrefix() {
-		assertThatThrownBy(() -> jwtProvider.getAccessToken("InvalidToken"))
+	void getToken_FromHeader_fail_invalidPrefix() {
+		assertThatThrownBy(() -> jwtProvider.getTokenFromHeader("InvalidToken"))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessage(UNAUTHENTICATED.getMessage());
 	}


### PR DESCRIPTION
## 연관된 이슈
#107 

## 작업 내용
- 토큰 생성 시 Member에 의존하지 않고 claims를 파라미터로 받아오도록 변경합니다.

## 스크린샷 (선택)

## 체크 리스트

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
