### PR TITLE
kopis api 호출에 retry 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'software.amazon.awssdk:s3:2.31.32'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     // Jwt
     implementation 'io.jsonwebtoken:jjwt:0.12.6'

--- a/backend/src/main/java/com/pickgo/domain/performance/kopis/service/KopisService.java
+++ b/backend/src/main/java/com/pickgo/domain/performance/kopis/service/KopisService.java
@@ -2,15 +2,22 @@ package com.pickgo.domain.performance.kopis.service;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.pickgo.domain.performance.kopis.dto.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
+@Slf4j
 public class KopisService {
     private final RestClient restClient;
     private final XmlMapper xmlMapper;
@@ -23,6 +30,10 @@ public class KopisService {
     }
 
     // 공연 목록
+    @Retryable(
+            retryFor = {IOException.class, HttpClientErrorException.class, RuntimeException.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     public List<String> fetchPerformanceIds(int page, int size) {
         LocalDate startDate = LocalDate.now();
         LocalDate endDate = startDate.plusMonths(3);
@@ -49,6 +60,10 @@ public class KopisService {
     }
 
     // 공연 상세
+    @Retryable(
+            retryFor = {IOException.class, HttpClientErrorException.class, RuntimeException.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     public KopisPerformanceDetailResponse fetchPerformanceDetail(String performanceId) {
         String xml = restClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -65,6 +80,10 @@ public class KopisService {
     }
 
     // 공연 시설 상세
+    @Retryable(
+            retryFor = {IOException.class, HttpClientErrorException.class, RuntimeException.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     public KopisVenueDetailResponse fetchVenueDetail(String venueId) {
         String xml = restClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -78,5 +97,23 @@ public class KopisService {
         } catch (Exception e) {
             throw new RuntimeException("공연 시설 상세 xml 파싱 실패", e);
         }
+    }
+
+    @Recover
+    public List<String> recoverPerformanceIds(RuntimeException e, int page, int size) {
+        log.warn("공연 목록 요청 재시도 실패 (page={}, size={}): {}", page, size, e.getMessage());
+        return List.of();
+    }
+
+    @Recover
+    public KopisPerformanceDetailResponse recoverPerformance(RuntimeException e, String id) {
+        log.warn("공연 상세 요청 재시도 실패 (id={}): {}", id, e.getMessage());
+        return null;
+    }
+
+    @Recover
+    public KopisVenueDetailResponse recoverVenue(RuntimeException e, String id) {
+        log.warn("공연장 상세 요청 재시도 실패 (id={}): {}", id, e.getMessage());
+        return null;
     }
 }

--- a/backend/src/main/java/com/pickgo/domain/performance/performance/service/PerformanceService.java
+++ b/backend/src/main/java/com/pickgo/domain/performance/performance/service/PerformanceService.java
@@ -64,6 +64,9 @@ public class PerformanceService {
         // 1. 공연 상세 조회
         KopisPerformanceDetailResponse performanceDetailResponse = kopisService.fetchPerformanceDetail(performanceId);
 
+        if (performanceRepository == null)
+            return;
+
         // 2. 공연 중복 체크
         if (performanceRepository.existsByNameAndPoster(performanceDetailResponse.getName(), performanceDetailResponse.getPoster())) {
             return;

--- a/backend/src/main/java/com/pickgo/global/config/RetryConfig.java
+++ b/backend/src/main/java/com/pickgo/global/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.pickgo.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.Retryable;
+
+@Configuration
+@Retryable
+public class RetryConfig {
+}


### PR DESCRIPTION
## 연관된 이슈
close #129 

## 작업 내용
- kopis api 호출 부분에 retry 추가 (3번 시도)
- 기본 목록 조회 캐싱 처리 중에 오류가 있어서 수정했습니다.
