### PR TITLE
예약 리펙토링

### DIFF
--- a/backend/src/main/java/com/pickgo/domain/performance/area/seat/event/SeatStatusChangedListener.java
+++ b/backend/src/main/java/com/pickgo/domain/performance/area/seat/event/SeatStatusChangedListener.java
@@ -4,20 +4,30 @@ import com.pickgo.domain.performance.area.seat.dto.SeatUpdateResponse;
 import com.pickgo.domain.performance.area.seat.entity.ReservedSeat;
 import com.pickgo.domain.performance.area.seat.service.SeatNotificationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SeatStatusChangedListener {
 
     private final SeatNotificationService seatNotificationService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleSeatStatusChangedEvent(SeatStatusChangedEvent event) {
-        ReservedSeat seat = event.getSeat();
-        Long sessionId = seat.getPerformanceSession().getId(); // 연관관계 필수
+        try {
+            ReservedSeat seat = event.getSeat();
+            Long sessionId = seat.getPerformanceSession().getId(); // 연관관계 필수
 
-        seatNotificationService.notifySeatUpdate(sessionId, SeatUpdateResponse.from(seat));
+            seatNotificationService.notifySeatUpdate(sessionId, SeatUpdateResponse.from(seat));
+        } catch (Exception e) {
+            log.warn("좌석 상태 변경 이벤트 처리 중 예외 발생", e);
+        }
     }
 }

--- a/backend/src/main/java/com/pickgo/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/pickgo/domain/reservation/service/ReservationService.java
@@ -1,11 +1,5 @@
 package com.pickgo.domain.reservation.service;
 
-import com.pickgo.domain.performance.area.area.entity.PerformanceArea;
-import com.pickgo.domain.performance.area.area.repository.PerformanceAreaRepository;
-import com.pickgo.domain.performance.area.seat.entity.ReservedSeat;
-import com.pickgo.domain.performance.area.seat.entity.SeatStatus;
-import com.pickgo.domain.performance.area.seat.event.SeatStatusChangedEvent;
-import com.pickgo.domain.performance.area.seat.repository.ReservedSeatRepository;
 import com.pickgo.domain.log.enums.ActionType;
 import com.pickgo.domain.member.member.entity.Member;
 import com.pickgo.domain.member.member.repository.MemberRepository;
@@ -13,6 +7,12 @@ import com.pickgo.domain.payment.entity.Payment;
 import com.pickgo.domain.payment.entity.PaymentStatus;
 import com.pickgo.domain.payment.repository.PaymentRepository;
 import com.pickgo.domain.payment.service.PaymentService;
+import com.pickgo.domain.performance.area.area.entity.PerformanceArea;
+import com.pickgo.domain.performance.area.area.repository.PerformanceAreaRepository;
+import com.pickgo.domain.performance.area.seat.entity.ReservedSeat;
+import com.pickgo.domain.performance.area.seat.entity.SeatStatus;
+import com.pickgo.domain.performance.area.seat.event.SeatStatusChangedEvent;
+import com.pickgo.domain.performance.area.seat.repository.ReservedSeatRepository;
 import com.pickgo.domain.performance.performance.entity.PerformanceSession;
 import com.pickgo.domain.performance.performance.repository.PerformanceSessionRepository;
 import com.pickgo.domain.reservation.dto.request.ReservationCreateRequest;
@@ -21,9 +21,9 @@ import com.pickgo.domain.reservation.dto.response.ReservationSimpleResponse;
 import com.pickgo.domain.reservation.entity.Reservation;
 import com.pickgo.domain.reservation.enums.ReservationStatus;
 import com.pickgo.domain.reservation.repository.ReservationRepository;
-import com.pickgo.global.response.PageResponse;
 import com.pickgo.global.exception.BusinessException;
 import com.pickgo.global.logging.util.LogWriter;
+import com.pickgo.global.response.PageResponse;
 import com.pickgo.global.response.RsCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -36,7 +36,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -56,82 +55,75 @@ public class ReservationService {
     private final PerformanceAreaRepository areaRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+
     public ReservationSimpleResponse createReservation(
             UUID memberId,
             ReservationCreateRequest request
     ) {
+        // 1. Member, Performance 검증 및 데이터 가져오기
+        Member member = validateMember(memberId);
+        PerformanceSession session = validateSession(request.performance_session_id());
+        validateReservationTime(session);
 
-        // 0. 유저 검증
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new BusinessException(MEMBER_NOT_FOUND)
-        );
+        // 2. 요청 좌석 생성
+        List<ReservedSeat> seats = generateReservedSeats(session, request.seats());
 
-        // 1. 공연 회차 검증
-        PerformanceSession performanceSession = sessionRepository.findById(request.performance_session_id()).orElseThrow(
-                () -> new BusinessException(PERFORMANCE_SESSION_NOT_FOUND)
-        );
+        // 3. 1,2번을 통해 예약 생성
+        return createReservationWithSeats(member, session, seats);
+    }
 
-        if (performanceSession.getReserveOpenAt().isAfter(LocalDateTime.now())
-                || performanceSession.getPerformanceTime().isBefore(LocalDateTime.now())) {
-            throw new BusinessException(RESERVATION_UNAVAILABLE);
-        }
+    private List<ReservedSeat> generateReservedSeats(PerformanceSession session, List<ReservationCreateRequest.SeatRequest> seatRequests) {
+        return seatRequests.stream()
+                .map(dto -> createReservedSeat(session, dto))
+                .toList();
+    }
 
-        // 2. 좌석 생성
-        List<ReservedSeat> reservedSeats = new ArrayList<>();
+    private ReservedSeat createReservedSeat(PerformanceSession session, ReservationCreateRequest.SeatRequest dto) {
+        PerformanceArea area = validateArea(dto.areaId());
 
-        for (ReservationCreateRequest.SeatRequest dto : request.seats()) {
-            PerformanceArea area = areaRepository.findById(dto.areaId())
-                    .orElseThrow(() -> new BusinessException(NOT_FOUND));
+        validateSeatPosition(area, dto);
 
-            // 입력값 검증
-            if (dto.row() < 1 || dto.row() > area.getRowCount()) {
-                throw new BusinessException(INVALID_SEAT_POSITION);
-            }
+        ReservedSeat seat = ReservedSeat.builder()
+                .performanceArea(area)
+                .row(String.valueOf((char) ('A' + dto.row() - 1)))
+                .number(dto.column())
+                .status(SeatStatus.PENDING)
+                .build();
 
-            if (dto.column() < 1 || dto.column() > area.getColCount()) {
-                throw new BusinessException(INVALID_SEAT_POSITION);
-            }
+        seat.setPerformanceSession(session);
+        return seat;
+    }
 
-            ReservedSeat reservedSeat = ReservedSeat.builder()
-                    .performanceArea(area)
-                    .row(String.valueOf((char) ('A' + dto.row() - 1)))
-                    .number(dto.column())
-                    .status(SeatStatus.PENDING)
-                    .build();
-
-            reservedSeat.setPerformanceSession(performanceSession); //세션 먼저 세팅
-            reservedSeats.add(reservedSeat);
-
-        }
-
-        // 여기부터 예약 트랜지션이므로 하나로 묶어야함
+    private ReservationSimpleResponse createReservationWithSeats(
+            Member member, PerformanceSession session, List<ReservedSeat> seats
+    ) {
         try {
-            // 3. 예약 내역 생성
-            // 3-1. 총 가격을 알기위해서는 reservedSeat의 가격 정보를 가져와함 -> area별로 다른 가격 계산 필요
-            int totalPrice = reservedSeats.stream()
+            int totalPrice = seats.stream()
                     .mapToInt(seat -> seat.getPerformanceArea().getPrice()).sum();
 
-            // 3-2. 예약 생성
+            // 예약 생성
             Reservation reservation = Reservation.builder()
                     .member(member)
-                    .performanceSession(performanceSession)
+                    .performanceSession(session)
                     .status(ReservationStatus.RESERVED)
                     .totalPrice(totalPrice)
                     .build();
 
-            // 4. 연관관계 세팅
+            // 연관관계 세팅
             member.addReservation(reservation);
-            reservation.updateReservedSeats(reservedSeats);
-            reservedSeats.forEach(seat -> seat.setReservation(reservation));
-            reservedSeats.forEach(seat -> seat.setPerformanceSession(performanceSession));
+            reservation.updateReservedSeats(seats);
+            seats.forEach(seat -> {
+                seat.setReservation(reservation);
+                seat.setPerformanceSession(session);
+            });
 
-            // 5. 좌석 및 예약 저장
+            // 좌석 및 예약 저장
             reservationRepository.save(reservation);
-            seatRepository.saveAll(reservedSeats);
+            seatRepository.saveAll(seats);
 
 
-            //예약 직후에 이벤트를 발행 (좌석이 점유되었음을 알림)
-            reservedSeats.forEach(seat -> {
+            // 예약 직후에 이벤트를 발행 (좌석이 점유되었음을 알림)
+            seats.forEach(seat -> {
                 applicationEventPublisher.publishEvent(new SeatStatusChangedEvent(seat));
             });
 
@@ -145,15 +137,18 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public ReservationDetailResponse getReservation(Long reservationId, UUID memberId) {
-        Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> new BusinessException(RESERVATION_NOT_FOUND));
+        Reservation reservation = validateReservation(reservationId);
 
         // 본인 예약인지 확인
+        validateReservationOwner(memberId, reservation);
+
+        return ReservationDetailResponse.from(reservation);
+    }
+
+    private void validateReservationOwner(UUID memberId, Reservation reservation) {
         if (!reservation.getMember().getId().equals(memberId)) {
             throw new BusinessException(RsCode.FORBIDDEN);
         }
-
-        return ReservationDetailResponse.from(reservation);
     }
 
     @Transactional(readOnly = true)
@@ -180,17 +175,10 @@ public class ReservationService {
             throw new BusinessException(RsCode.INVALID_RESERVATION_STATE);
         }
 
-
-        //삭제 되기전에 , 좌석 해제 이벤트를 발행하고, 프론트에서 이벤트를 받으면 좌석을 활성화하는 방식 , 예약 삭제 -> 좌석 선택 가능
-        reservation.getReservedSeats().forEach(seat -> {
-            seat.setStatus(SeatStatus.RELEASED);
-            applicationEventPublisher.publishEvent(new SeatStatusChangedEvent(seat));
-        });
-
-      
+        // 2. 좌석 활성화 및 SSE 이벤트 발행
+        releaseSeatsAndPublishEvent(reservation);
 
         // 3. 예약 삭제
-
         reservationRepository.delete(reservation);
 
         // 4. 로깅
@@ -203,12 +191,8 @@ public class ReservationService {
      */
     public void cancelReservation(Long reservationId) {
         // 1. 예약과 결제를 조회
-        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(
-                () -> new BusinessException(RESERVATION_NOT_FOUND)
-        );
-        Payment payment = paymentRepository.findByReservation(reservation).orElseThrow(
-                () -> new BusinessException(NOT_FOUND)
-        );
+        Reservation reservation = validateReservation(reservationId);
+        Payment payment = validatePayment(reservation);
 
         // 2. TOSS 결제 취소 + 상태 변경
         if (payment.getStatus() == PaymentStatus.COMPLETED) {
@@ -218,17 +202,62 @@ public class ReservationService {
         // 3. 예약 상태 변경
         reservation.cancel();
 
+        // 4. 좌석 해제 및 이벤트 발행
+        releaseSeatsAndPublishEvent(reservation);
 
-        //예약 취소시 좌석 해제 했다는 알림 발송,
+        // 5. 예약된 좌석 복구
+        reservation.getReservedSeats().clear();
+
+        // 6. 로깅
+        logWriter.writeReservationLog(reservation, ActionType.RESERVATION_CANCELED);
+    }
+
+    private Payment validatePayment(Reservation reservation) {
+        return paymentRepository.findByReservation(reservation).orElseThrow(
+                () -> new BusinessException(NOT_FOUND)
+        );
+    }
+
+    private void releaseSeatsAndPublishEvent(Reservation reservation) {
         reservation.getReservedSeats().forEach(seat -> {
             seat.setStatus(SeatStatus.RELEASED);
             applicationEventPublisher.publishEvent(new SeatStatusChangedEvent(seat));
         });
+    }
 
-        // 4. 예약된 좌석 복구
-        reservation.getReservedSeats().clear();
+    private void validateSeatPosition(PerformanceArea area, ReservationCreateRequest.SeatRequest dto) {
+        if (dto.row() < 1 || dto.row() > area.getRowCount()
+                || dto.column() < 1 || dto.column() > area.getColCount()) {
+            throw new BusinessException(INVALID_SEAT_POSITION);
+        }
+    }
 
-        // 5. 로깅
-        logWriter.writeReservationLog(reservation, ActionType.RESERVATION_CANCELED);
+    private PerformanceArea validateArea(Long areaId) {
+        return areaRepository.findById(areaId)
+                .orElseThrow(() -> new BusinessException(NOT_FOUND));
+    }
+
+    private void validateReservationTime(PerformanceSession performanceSession) {
+        if (performanceSession.getReserveOpenAt().isAfter(LocalDateTime.now())
+                || performanceSession.getPerformanceTime().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(RESERVATION_UNAVAILABLE);
+        }
+    }
+
+    private PerformanceSession validateSession(Long performanceSessionId) {
+        return sessionRepository.findById(performanceSessionId).orElseThrow(
+                () -> new BusinessException(PERFORMANCE_SESSION_NOT_FOUND)
+        );
+    }
+
+    private Member validateMember(UUID memberId) {
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new BusinessException(MEMBER_NOT_FOUND)
+        );
+    }
+
+    private Reservation validateReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new BusinessException(RESERVATION_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 연관된 이슈

> ex) #131 
## 작업 내용

### **1. 좌석 상태 변경 이벤트 발행 로직 개선**

- 기존에는 applicationEventPublisher.publishEvent(...) 로 이벤트 즉시 발행
    
    → 예약 트랜잭션이 **완료되기 전에 SSE가 전송되는 문제** 발생(정합성 문제)
   
- 변경: @TransactionalEventListener(phase = AFTER_COMMIT) + REQUIRES_NEW 로 별도 트랜잭션에서 처리되도록 하고, 메인 트랜잭션 커밋 후 작동하게 함
- **예약 완료 후 좌석 상태 반영되도록 정합성 확보**
- 리스너 내부 예외 try-catch로 방어 처리

### **2. ReservationService 리팩토링**

- 메서드의 가독성 및 유지보수성을 위해 다음과 같이 구조 분리
- 각 단위 로직의 **의도 명확화 및 테스트 용이성 향상**

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 스크린샷 (선택)

## 체크 리스트

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
